### PR TITLE
Fix handling of paths with spaces

### DIFF
--- a/epub2mobi.py
+++ b/epub2mobi.py
@@ -2,6 +2,7 @@
 
 import os
 from functools import reduce
+from subprocess import call
 
 
 def epub2mobi(fromdir, todir, ignore_if=None):
@@ -26,8 +27,7 @@ def epub2mobi(fromdir, todir, ignore_if=None):
                 if ext == '.epub':
                     mobi = os.path.join(todir, nm + '.mobi')
                     if not os.path.exists(mobi):
-                        os.system('ebook-convert ' +
-                                  os.path.join(root, fl) + ' ' + mobi)
+                        call(('ebook-convert', os.path.join(root, fl), mobi))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`os.system` should never be used.
Use `subprocess.call` instead, which allows passing arguments separately.